### PR TITLE
Chroe[FC_1]: 초기 아이템 설정, 게임 HUD 위젯 추가

### DIFF
--- a/Assets/Resources/InventoryDatabase.asset
+++ b/Assets/Resources/InventoryDatabase.asset
@@ -25,4 +25,16 @@ MonoBehaviour:
   - ID: 12261000
     Count: 1
     IsEquipped: 0
+  - ID: 10043035
+    Count: 5
+    IsEquipped: 0
+  - ID: 10072051
+    Count: 3
+    IsEquipped: 0
+  - ID: 10074071
+    Count: 3
+    IsEquipped: 0
+  - ID: 10053009
+    Count: 5
+    IsEquipped: 0
   maxSlotCount: 30

--- a/Assets/Resources/UI/UI_GameScene.prefab
+++ b/Assets/Resources/UI/UI_GameScene.prefab
@@ -1694,10 +1694,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 38fd2c2ad1a85cf4b9fafb8837a31dec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fixedWidgets: []
+  fixedWidgets:
+  - {fileID: 6842411262333723180}
   interaction: {fileID: 4983921868044949536}
   interactText: {fileID: 3699588668553901865}
-  FadeEffect: {fileID: 0}
 --- !u!225 &5520538655938796520
 CanvasGroup:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 🔎 작업 내용

- 초기 아이템 추가했습니다. 
1) 벚꽃나무 : 5개 
2) 금괴 : 3개
3) 달빛나무 판자 : 3개
4) 석영 : 5개

<br/>

## 🐞 수정된 버그

- 위젯이 빠져있던 문제 해결
